### PR TITLE
#62 [1h] bugfix device state values to nullable per type

### DIFF
--- a/aidlc-docs/aidlc-state.md
+++ b/aidlc-docs/aidlc-state.md
@@ -39,6 +39,6 @@
 
 ## Current Status
 - **Lifecycle Phase**: CONSTRUCTION
-- **Current Stage**: Build and Test (Bugfix #63: email-validation) — complete
-- **Next Stage**: User review / PR
-- **Status**: All checks pass — BUILD SUCCESS
+- **Current Stage**: Code Generation (Bugfix #62: device-state) — complete
+- **Next Stage**: Build and Test
+- **Status**: Code generated, 126/126 tests pass — awaiting user review

--- a/aidlc-docs/audit.md
+++ b/aidlc-docs/audit.md
@@ -1,5 +1,13 @@
 # AI-DLC Audit Log
 
+## Code Generation Plan — Bugfix #62: Device State Null-Safety Per Type
+**Timestamp**: 2026-04-23T00:00:00
+**AI Prompt**: "yes please start fixing that with ai-dlc"
+**Plan**: `aidlc-docs/construction/plans/62-bugfix-device-state-code-generation-plan.md`
+**Status**: Approved by user — code generation complete. 126/126 tests pass.
+
+---
+
 ## Code Generation Plan — Bugfix #63: Email Case-Insensitivity
 **Timestamp**: 2026-04-23T00:00:00
 **AI Prompt**: "using ai-dlc, I want to implement 63-bugfix-email-validation-plan.md"

--- a/aidlc-docs/construction/plans/62-bugfix-device-state-code-generation-plan.md
+++ b/aidlc-docs/construction/plans/62-bugfix-device-state-code-generation-plan.md
@@ -1,0 +1,74 @@
+# Code Generation Plan — Bugfix #62: Device State Null-Safety Per Type
+
+## Unit Context
+
+- **Unit Name**: bugfix-device-state
+- **Branch**: `62-bugfix-devices-state`
+- **Bug Reference**: Issue #62
+- **Source Plan**: `localDocs/62-bugfix-device-state-plan.md`
+- **Scope**: Backend only — `DeviceResponse.java` + `DeviceService.java`
+- **Type**: Brownfield modification (modify existing files, no new files created)
+
+## Stories / Acceptance Criteria
+
+- [ ] **AC-1**: A SWITCH device response contains only `stateOn` — all other state fields are `null`
+- [ ] **AC-2**: A DIMMER device response contains `stateOn` and `brightness` — all others `null`
+- [ ] **AC-3**: A THERMOSTAT device response contains `stateOn` and `temperature` — all others `null`
+- [ ] **AC-4**: A SENSOR device response contains `temperature` and `sensorValue` — all others `null`
+- [ ] **AC-5**: A COVER device response contains `stateOn` and `coverPosition` — all others `null`
+
+## Dependencies
+
+- No dependency on other units
+- No DB migration required
+- No frontend changes required
+
+## Affected Files
+
+| File | Action |
+|------|--------|
+| `backend/src/main/java/at/jku/se/smarthome/dto/DeviceResponse.java` | **Modify** — change primitive state fields to nullable wrapper types |
+| `backend/src/main/java/at/jku/se/smarthome/service/DeviceService.java` | **Modify** — add type-aware null filtering in `toResponse()` |
+| `backend/src/test/java/at/jku/se/smarthome/service/DeviceServiceTest.java` | **Modify** — add/update test cases for each device type |
+
+---
+
+## Step-by-Step Plan
+
+### Step 1 — Modify `DeviceResponse.java` [x]
+Change all state fields from primitive to wrapper types:
+- `boolean stateOn` → `Boolean stateOn`
+- `int brightness` → `Integer brightness`
+- `double temperature` → `Double temperature`
+- `double sensorValue` → `Double sensorValue`
+- `int coverPosition` → `Integer coverPosition`
+
+Update constructor(s) and getters/setters accordingly.
+Ensure Javadoc is present on the class and all public methods.
+
+### Step 2 — Modify `DeviceService.toResponse()` [x]
+Replace the unconditional field copy with a `switch` on `device.getType()` that only populates applicable fields per type, leaving all others as `null`. See plan for exact mapping.
+Ensure Javadoc on `toResponse()` is updated.
+PMD review: no unused variables, no empty blocks, specific exception types.
+
+### Step 3 — Add / Update Unit Tests in `DeviceServiceTest.java` [x]
+Add or update test cases verifying:
+1. `SWITCH` → only `stateOn` non-null
+2. `DIMMER` → only `stateOn` + `brightness` non-null
+3. `THERMOSTAT` → only `stateOn` + `temperature` non-null
+4. `SENSOR` → only `temperature` + `sensorValue` non-null
+5. `COVER` → only `stateOn` + `coverPosition` non-null
+
+### Step 4 — PMD & Javadoc Review [x]
+- Verify no PMD violations in modified methods
+- Verify Javadoc present on all modified public classes/methods
+
+---
+
+## Completion Criteria
+
+- [ ] Step 1 complete — `DeviceResponse` uses wrapper types
+- [ ] Step 2 complete — `toResponse()` is type-aware
+- [ ] Step 3 complete — unit tests added/updated
+- [ ] Step 4 complete — PMD + Javadoc verified
+- [ ] AC-1 through AC-5 satisfied

--- a/backend/src/main/java/at/jku/se/smarthome/dto/DeviceResponse.java
+++ b/backend/src/main/java/at/jku/se/smarthome/dto/DeviceResponse.java
@@ -7,6 +7,11 @@ import at.jku.se.smarthome.domain.DeviceType;
  *
  * <p>FR-04: add virtual smart devices.
  * FR-06: includes persisted device state fields.</p>
+ *
+ * <p>State fields use wrapper types so that inapplicable fields for a given
+ * device type are returned as {@code null} rather than a misleading default value.
+ * For example, a {@code SWITCH} device will have {@code null} for brightness,
+ * temperature, sensorValue, and coverPosition.</p>
  */
 public class DeviceResponse {
 
@@ -19,20 +24,20 @@ public class DeviceResponse {
     /** The device type, serialized as a lowercase string. */
     private DeviceType type;
 
-    /** Whether the device is switched on. */
-    private boolean stateOn;
+    /** Whether the device is switched on, or {@code null} if not applicable for this type. */
+    private Boolean stateOn;
 
-    /** Brightness level (0–100), used by dimmer devices. */
-    private int brightness;
+    /** Brightness level (0–100) for dimmer devices, or {@code null} if not applicable. */
+    private Integer brightness;
 
-    /** Thermostat target temperature in degrees Celsius. */
-    private double temperature;
+    /** Thermostat target temperature in degrees Celsius, or {@code null} if not applicable. */
+    private Double temperature;
 
-    /** Current sensor reading. */
-    private double sensorValue;
+    /** Current sensor reading, or {@code null} if not applicable. */
+    private Double sensorValue;
 
-    /** Cover position: 0 = closed, 100 = open. */
-    private int coverPosition;
+    /** Cover position (0 = closed, 100 = open), or {@code null} if not applicable. */
+    private Integer coverPosition;
 
     /**
      * Creates a DeviceResponse without state (defaults to off/50/21/0/0).
@@ -49,21 +54,22 @@ public class DeviceResponse {
     }
 
     /**
-     * Creates a DeviceResponse with full state.
+     * Creates a DeviceResponse with type-aware state.
      * Used by FR-06 endpoints that return persisted state.
+     * Fields that are not applicable for the device type are passed as {@code null}.
      *
      * @param id            the device id
      * @param name          the device name
      * @param type          the device type
-     * @param stateOn       whether the device is on
-     * @param brightness    brightness level (0–100)
-     * @param temperature   thermostat target temperature
-     * @param sensorValue   current sensor reading
-     * @param coverPosition cover position (0 or 100)
+     * @param stateOn       whether the device is on, or {@code null} if not applicable
+     * @param brightness    brightness level (0–100), or {@code null} if not applicable
+     * @param temperature   thermostat target temperature, or {@code null} if not applicable
+     * @param sensorValue   current sensor reading, or {@code null} if not applicable
+     * @param coverPosition cover position (0 or 100), or {@code null} if not applicable
      */
     public DeviceResponse(Long id, String name, DeviceType type,
-                          boolean stateOn, int brightness, double temperature,
-                          double sensorValue, int coverPosition) {
+                          Boolean stateOn, Integer brightness, Double temperature,
+                          Double sensorValue, Integer coverPosition) {
         this.id = id;
         this.name = name;
         this.type = type;
@@ -102,47 +108,47 @@ public class DeviceResponse {
     }
 
     /**
-     * Returns whether the device is switched on.
+     * Returns whether the device is switched on, or {@code null} if not applicable for this type.
      *
-     * @return {@code true} if on
+     * @return {@code true} if on, {@code false} if off, {@code null} if not applicable
      */
-    public boolean isStateOn() {
+    public Boolean isStateOn() {
         return stateOn;
     }
 
     /**
-     * Returns the brightness level.
+     * Returns the brightness level, or {@code null} if not applicable for this type.
      *
-     * @return brightness (0–100)
+     * @return brightness (0–100), or {@code null}
      */
-    public int getBrightness() {
+    public Integer getBrightness() {
         return brightness;
     }
 
     /**
-     * Returns the thermostat target temperature.
+     * Returns the thermostat target temperature, or {@code null} if not applicable for this type.
      *
-     * @return temperature in degrees Celsius
+     * @return temperature in degrees Celsius, or {@code null}
      */
-    public double getTemperature() {
+    public Double getTemperature() {
         return temperature;
     }
 
     /**
-     * Returns the current sensor value.
+     * Returns the current sensor value, or {@code null} if not applicable for this type.
      *
-     * @return sensor reading
+     * @return sensor reading, or {@code null}
      */
-    public double getSensorValue() {
+    public Double getSensorValue() {
         return sensorValue;
     }
 
     /**
-     * Returns the cover position.
+     * Returns the cover position, or {@code null} if not applicable for this type.
      *
-     * @return 0 for closed, 100 for open
+     * @return 0 for closed, 100 for open, or {@code null}
      */
-    public int getCoverPosition() {
+    public Integer getCoverPosition() {
         return coverPosition;
     }
 }

--- a/backend/src/main/java/at/jku/se/smarthome/service/DeviceService.java
+++ b/backend/src/main/java/at/jku/se/smarthome/service/DeviceService.java
@@ -182,11 +182,48 @@ public class DeviceService {
         return response;
     }
 
+    /**
+     * Converts a {@link Device} entity to a {@link DeviceResponse}, applying type-aware
+     * null filtering so that state fields irrelevant to the device type are returned as
+     * {@code null} instead of a misleading default value.
+     *
+     * @param d the device entity to convert
+     * @return a response DTO with only the applicable state fields populated
+     */
     private static DeviceResponse toResponse(Device d) {
+        Boolean stateOn = null;
+        Integer brightness = null;
+        Double temperature = null;
+        Double sensorValue = null;
+        Integer coverPosition = null;
+
+        switch (d.getType()) {
+            case SWITCH:
+                stateOn = d.isStateOn();
+                break;
+            case DIMMER:
+                stateOn = d.isStateOn();
+                brightness = d.getBrightness();
+                break;
+            case THERMOSTAT:
+                stateOn = d.isStateOn();
+                temperature = d.getTemperature();
+                break;
+            case SENSOR:
+                temperature = d.getTemperature();
+                sensorValue = d.getSensorValue();
+                break;
+            case COVER:
+                stateOn = d.isStateOn();
+                coverPosition = d.getCoverPosition();
+                break;
+            default:
+                break;
+        }
+
         return new DeviceResponse(
                 d.getId(), d.getName(), d.getType(),
-                d.isStateOn(), d.getBrightness(), d.getTemperature(),
-                d.getSensorValue(), d.getCoverPosition());
+                stateOn, brightness, temperature, sensorValue, coverPosition);
     }
 
     private Room getOwnedRoom(String email, Long roomId) {

--- a/backend/src/test/java/at/jku/se/smarthome/service/DeviceServiceTest.java
+++ b/backend/src/test/java/at/jku/se/smarthome/service/DeviceServiceTest.java
@@ -270,4 +270,86 @@ class DeviceServiceTest {
         req.setName(name);
         return req;
     }
+
+    // --- Bugfix #62: type-aware null filtering in toResponse() ---
+
+    @Test
+    void toResponse_switch_onlyStateOnIsNonNull() {
+        Device device = new Device(room, "Switch", DeviceType.SWITCH);
+        when(userRepository.findByEmail("user@test.com")).thenReturn(Optional.of(user));
+        when(roomRepository.findByIdAndUserId(1L, user.getId())).thenReturn(Optional.of(room));
+        when(deviceRepository.findByRoomIdOrderByCreatedAtAsc(room.getId())).thenReturn(List.of(device));
+
+        DeviceResponse response = deviceService.getDevices("user@test.com", 1L).get(0);
+
+        assertThat(response.isStateOn()).isNotNull();
+        assertThat(response.getBrightness()).isNull();
+        assertThat(response.getTemperature()).isNull();
+        assertThat(response.getSensorValue()).isNull();
+        assertThat(response.getCoverPosition()).isNull();
+    }
+
+    @Test
+    void toResponse_dimmer_onlyStateOnAndBrightnessAreNonNull() {
+        Device device = new Device(room, "Dimmer", DeviceType.DIMMER);
+        when(userRepository.findByEmail("user@test.com")).thenReturn(Optional.of(user));
+        when(roomRepository.findByIdAndUserId(1L, user.getId())).thenReturn(Optional.of(room));
+        when(deviceRepository.findByRoomIdOrderByCreatedAtAsc(room.getId())).thenReturn(List.of(device));
+
+        DeviceResponse response = deviceService.getDevices("user@test.com", 1L).get(0);
+
+        assertThat(response.isStateOn()).isNotNull();
+        assertThat(response.getBrightness()).isNotNull();
+        assertThat(response.getTemperature()).isNull();
+        assertThat(response.getSensorValue()).isNull();
+        assertThat(response.getCoverPosition()).isNull();
+    }
+
+    @Test
+    void toResponse_thermostat_onlyStateOnAndTemperatureAreNonNull() {
+        Device device = new Device(room, "Thermostat", DeviceType.THERMOSTAT);
+        when(userRepository.findByEmail("user@test.com")).thenReturn(Optional.of(user));
+        when(roomRepository.findByIdAndUserId(1L, user.getId())).thenReturn(Optional.of(room));
+        when(deviceRepository.findByRoomIdOrderByCreatedAtAsc(room.getId())).thenReturn(List.of(device));
+
+        DeviceResponse response = deviceService.getDevices("user@test.com", 1L).get(0);
+
+        assertThat(response.isStateOn()).isNotNull();
+        assertThat(response.getBrightness()).isNull();
+        assertThat(response.getTemperature()).isNotNull();
+        assertThat(response.getSensorValue()).isNull();
+        assertThat(response.getCoverPosition()).isNull();
+    }
+
+    @Test
+    void toResponse_sensor_onlyTemperatureAndSensorValueAreNonNull() {
+        Device device = new Device(room, "Sensor", DeviceType.SENSOR);
+        when(userRepository.findByEmail("user@test.com")).thenReturn(Optional.of(user));
+        when(roomRepository.findByIdAndUserId(1L, user.getId())).thenReturn(Optional.of(room));
+        when(deviceRepository.findByRoomIdOrderByCreatedAtAsc(room.getId())).thenReturn(List.of(device));
+
+        DeviceResponse response = deviceService.getDevices("user@test.com", 1L).get(0);
+
+        assertThat(response.isStateOn()).isNull();
+        assertThat(response.getBrightness()).isNull();
+        assertThat(response.getTemperature()).isNotNull();
+        assertThat(response.getSensorValue()).isNotNull();
+        assertThat(response.getCoverPosition()).isNull();
+    }
+
+    @Test
+    void toResponse_cover_onlyStateOnAndCoverPositionAreNonNull() {
+        Device device = new Device(room, "Cover", DeviceType.COVER);
+        when(userRepository.findByEmail("user@test.com")).thenReturn(Optional.of(user));
+        when(roomRepository.findByIdAndUserId(1L, user.getId())).thenReturn(Optional.of(room));
+        when(deviceRepository.findByRoomIdOrderByCreatedAtAsc(room.getId())).thenReturn(List.of(device));
+
+        DeviceResponse response = deviceService.getDevices("user@test.com", 1L).get(0);
+
+        assertThat(response.isStateOn()).isNotNull();
+        assertThat(response.getBrightness()).isNull();
+        assertThat(response.getTemperature()).isNull();
+        assertThat(response.getSensorValue()).isNull();
+        assertThat(response.getCoverPosition()).isNotNull();
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes #62 — device state fields (brightness, temperature, sensorValue, coverPosition) were always returned with non-null defaults regardless of device type
- Changed `DeviceResponse` state fields from primitives to wrapper types (`Boolean`, `Integer`, `Double`) so inapplicable fields can be `null`
- Added type-aware `toResponse()` in `DeviceService` using a switch on device type

## Test plan
- [ ] SWITCH → only `stateOn` non-null
- [ ] DIMMER → only `stateOn` + `brightness` non-null
- [ ] THERMOSTAT → only `stateOn` + `temperature` non-null
- [ ] SENSOR → only `temperature` + `sensorValue` non-null
- [ ] COVER → only `stateOn` + `coverPosition` non-null
- [ ] Full test suite: 126/126 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)