### PR TITLE
#95 [1h] refactoring and minor bugfixes in dashboard,  1. Dead code —…

### DIFF
--- a/backend/src/main/java/at/jku/se/smarthome/dto/DeviceStateRequest.java
+++ b/backend/src/main/java/at/jku/se/smarthome/dto/DeviceStateRequest.java
@@ -8,6 +8,31 @@ package at.jku.se.smarthome.dto;
  */
 public class DeviceStateRequest {
 
+    /**
+     * Creates a {@code DeviceStateRequest} from a string action value as stored in rules and scenes.
+     *
+     * <p>For COVER devices, {@code "open"} maps to {@code stateOn=true, coverPosition=100}
+     * and {@code "close"} maps to {@code stateOn=false, coverPosition=0}.
+     * For all other device types, {@code "true"} maps to {@code stateOn=true}
+     * and any other value maps to {@code stateOn=false}.</p>
+     *
+     * @param isCover     {@code true} if the target device is a COVER type
+     * @param actionValue the stored action string (e.g. {@code "true"}, {@code "false"},
+     *                    {@code "open"}, {@code "close"})
+     * @return a new {@code DeviceStateRequest} with the appropriate fields set
+     */
+    public static DeviceStateRequest fromActionValue(boolean isCover, String actionValue) {
+        DeviceStateRequest req = new DeviceStateRequest();
+        if (isCover) {
+            boolean open = "open".equalsIgnoreCase(actionValue);
+            req.setStateOn(open);
+            req.setCoverPosition(open ? 100 : 0);
+        } else {
+            req.setStateOn("true".equalsIgnoreCase(actionValue));
+        }
+        return req;
+    }
+
     /** New on/off state. {@code null} = no change. */
     private Boolean stateOn;
 

--- a/backend/src/main/java/at/jku/se/smarthome/service/RuleService.java
+++ b/backend/src/main/java/at/jku/se/smarthome/service/RuleService.java
@@ -11,7 +11,6 @@ import at.jku.se.smarthome.dto.RuleRequest;
 import at.jku.se.smarthome.dto.RuleResponse;
 import at.jku.se.smarthome.repository.DeviceRepository;
 import at.jku.se.smarthome.repository.RuleRepository;
-import at.jku.se.smarthome.repository.UserRepository;
 import at.jku.se.smarthome.websocket.DeviceWebSocketHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +45,6 @@ public class RuleService {
 
     private final RuleRepository ruleRepository;
     private final DeviceRepository deviceRepository;
-    private final UserRepository userRepository;
     private final DeviceService deviceService;
     private final DeviceWebSocketHandler wsHandler;
     private final MemberService memberService;
@@ -56,20 +54,17 @@ public class RuleService {
      *
      * @param ruleRepository   the repository for rule persistence
      * @param deviceRepository the repository for device lookups and ownership checks
-     * @param userRepository   the repository for user lookups
      * @param deviceService    the service used to apply device state when a rule fires
      * @param wsHandler        the WebSocket handler used to push rule notifications to the frontend
      * @param memberService    the service used for owner-only authorization (FR-13)
      */
     public RuleService(RuleRepository ruleRepository,
                        DeviceRepository deviceRepository,
-                       UserRepository userRepository,
                        DeviceService deviceService,
                        DeviceWebSocketHandler wsHandler,
                        MemberService memberService) {
         this.ruleRepository = ruleRepository;
         this.deviceRepository = deviceRepository;
-        this.userRepository = userRepository;
         this.deviceService = deviceService;
         this.wsHandler = wsHandler;
         this.memberService = memberService;
@@ -334,15 +329,9 @@ public class RuleService {
     }
 
     private DeviceStateRequest buildActionRequest(Rule rule) {
-        DeviceStateRequest req = new DeviceStateRequest();
-        if (rule.getActionDevice().getType() == DeviceType.COVER) {
-            boolean open = "open".equalsIgnoreCase(rule.getActionValue());
-            req.setStateOn(open);
-            req.setCoverPosition(open ? 100 : 0);
-        } else {
-            req.setStateOn("true".equalsIgnoreCase(rule.getActionValue()));
-        }
-        return req;
+        return DeviceStateRequest.fromActionValue(
+                rule.getActionDevice().getType() == DeviceType.COVER,
+                rule.getActionValue());
     }
 
     private Device resolveTriggerDevice(User user, RuleRequest request) {
@@ -400,11 +389,6 @@ public class RuleService {
             case "close" -> "open";
             default      -> null;
         };
-    }
-
-    private User resolveUser(String email) {
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found."));
     }
 
     /**

--- a/backend/src/main/java/at/jku/se/smarthome/service/SceneService.java
+++ b/backend/src/main/java/at/jku/se/smarthome/service/SceneService.java
@@ -224,17 +224,9 @@ public class SceneService {
     }
 
     private DeviceStateRequest buildStateRequest(SceneEntry entry) {
-        DeviceStateRequest req = new DeviceStateRequest();
-        String action = entry.getActionValue();
-
-        if (entry.getDevice().getType() == DeviceType.COVER) {
-            boolean open = "open".equalsIgnoreCase(action);
-            req.setStateOn(open);
-            req.setCoverPosition(open ? 100 : 0);
-        } else {
-            req.setStateOn("true".equalsIgnoreCase(action));
-        }
-        return req;
+        return DeviceStateRequest.fromActionValue(
+                entry.getDevice().getType() == DeviceType.COVER,
+                entry.getActionValue());
     }
 
     private Scene resolveOwnedScene(User user, Long sceneId) {

--- a/backend/src/main/java/at/jku/se/smarthome/service/ScheduleService.java
+++ b/backend/src/main/java/at/jku/se/smarthome/service/ScheduleService.java
@@ -8,7 +8,6 @@ import at.jku.se.smarthome.dto.ScheduleRequest;
 import at.jku.se.smarthome.dto.ScheduleResponse;
 import at.jku.se.smarthome.repository.DeviceRepository;
 import at.jku.se.smarthome.repository.ScheduleRepository;
-import at.jku.se.smarthome.repository.UserRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
@@ -44,7 +43,6 @@ public class ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
     private final DeviceRepository deviceRepository;
-    private final UserRepository userRepository;
     private final DeviceService deviceService;
     private final ActivityLogService activityLogService;
     private final ObjectMapper objectMapper;
@@ -55,7 +53,6 @@ public class ScheduleService {
      *
      * @param scheduleRepository  the repository for schedule persistence
      * @param deviceRepository    the repository for device lookups
-     * @param userRepository      the repository for user lookups
      * @param deviceService       the service used to apply device state on execution
      * @param activityLogService  the service used to log execution results
      * @param objectMapper        the Jackson mapper for action payload deserialization
@@ -63,14 +60,12 @@ public class ScheduleService {
      */
     public ScheduleService(ScheduleRepository scheduleRepository,
                            DeviceRepository deviceRepository,
-                           UserRepository userRepository,
                            DeviceService deviceService,
                            ActivityLogService activityLogService,
                            ObjectMapper objectMapper,
                            MemberService memberService) {
         this.scheduleRepository = scheduleRepository;
         this.deviceRepository = deviceRepository;
-        this.userRepository = userRepository;
         this.deviceService = deviceService;
         this.activityLogService = activityLogService;
         this.objectMapper = objectMapper;
@@ -112,8 +107,7 @@ public class ScheduleService {
      */
     @Transactional(readOnly = true)
     public List<ScheduleResponse> getSchedules(String userEmail, Long deviceId) {
-        memberService.requireOwnerRole(userEmail);
-        User user = memberService.resolveEffectiveOwner(userEmail);
+        User user = resolveOwner(userEmail);
         List<Schedule> schedules;
         if (deviceId != null) {
             Device device = resolveOwnedDevice(user, deviceId);
@@ -137,8 +131,7 @@ public class ScheduleService {
      */
     @Transactional
     public ScheduleResponse createSchedule(String userEmail, ScheduleRequest request) {
-        memberService.requireOwnerRole(userEmail);
-        User user = memberService.resolveEffectiveOwner(userEmail);
+        User user = resolveOwner(userEmail);
         Device device = resolveOwnedDevice(user, request.getDeviceId());
         validateRequest(request);
 
@@ -170,8 +163,7 @@ public class ScheduleService {
      */
     @Transactional
     public ScheduleResponse updateSchedule(String userEmail, Long scheduleId, ScheduleRequest request) {
-        memberService.requireOwnerRole(userEmail);
-        User user = memberService.resolveEffectiveOwner(userEmail);
+        User user = resolveOwner(userEmail);
         Schedule schedule = resolveOwnedSchedule(user, scheduleId);
         validateRequest(request);
 
@@ -204,8 +196,7 @@ public class ScheduleService {
      */
     @Transactional
     public ScheduleResponse setEnabled(String userEmail, Long scheduleId, boolean enabled) {
-        memberService.requireOwnerRole(userEmail);
-        User user = memberService.resolveEffectiveOwner(userEmail);
+        User user = resolveOwner(userEmail);
         Schedule schedule = resolveOwnedSchedule(user, scheduleId);
         schedule.setEnabled(enabled);
         return toResponse(scheduleRepository.save(schedule));
@@ -220,8 +211,7 @@ public class ScheduleService {
      */
     @Transactional
     public void deleteSchedule(String userEmail, Long scheduleId) {
-        memberService.requireOwnerRole(userEmail);
-        User user = memberService.resolveEffectiveOwner(userEmail);
+        User user = resolveOwner(userEmail);
         Schedule schedule = resolveOwnedSchedule(user, scheduleId);
         scheduleRepository.delete(schedule);
         if (log.isInfoEnabled()) {
@@ -274,9 +264,9 @@ public class ScheduleService {
 
     // ── Private helpers ────────────────────────────────────────────────────────
 
-    private User resolveUser(String email) {
-        return userRepository.findByEmail(email)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User not found."));
+    private User resolveOwner(String email) {
+        memberService.requireOwnerRole(email);
+        return memberService.resolveEffectiveOwner(email);
     }
 
     private Device resolveOwnedDevice(User user, Long deviceId) {

--- a/backend/src/test/java/at/jku/se/smarthome/service/DeviceServiceTest.java
+++ b/backend/src/test/java/at/jku/se/smarthome/service/DeviceServiceTest.java
@@ -72,7 +72,7 @@ class DeviceServiceTest {
                 // no-op: WebSocket activity log broadcast is tested separately
             }
         };
-        RuleService noOpRuleService = new RuleService(null, null, null, null, null, null) {
+        RuleService noOpRuleService = new RuleService(null, null, null, null, null) {
             @Override
             public void evaluateRulesForDevice(Device device,
                                                DeviceStateRequest request,
@@ -350,7 +350,7 @@ class DeviceServiceTest {
     @Test
     void updateState_broadcastsDeviceAndActivityLogToHouseholdRecipients() {
         CapturingWebSocketHandler ws = new CapturingWebSocketHandler();
-        RuleService noOpRuleService = new RuleService(null, null, null, null, null, null) {
+        RuleService noOpRuleService = new RuleService(null, null, null, null, null) {
             @Override
             public void evaluateRulesForDevice(Device device,
                                                DeviceStateRequest request,

--- a/backend/src/test/java/at/jku/se/smarthome/service/RuleServiceTest.java
+++ b/backend/src/test/java/at/jku/se/smarthome/service/RuleServiceTest.java
@@ -13,7 +13,6 @@ import at.jku.se.smarthome.dto.RuleRequest;
 import at.jku.se.smarthome.dto.RuleResponse;
 import at.jku.se.smarthome.repository.DeviceRepository;
 import at.jku.se.smarthome.repository.RuleRepository;
-import at.jku.se.smarthome.repository.UserRepository;
 import at.jku.se.smarthome.websocket.DeviceWebSocketHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,7 +43,6 @@ class RuleServiceTest {
 
     @Mock private RuleRepository ruleRepository;
     @Mock private DeviceRepository deviceRepository;
-    @Mock private UserRepository userRepository;
     @Mock private DeviceService deviceService;
     @Mock private DeviceWebSocketHandler wsHandler;
     @Mock private MemberService memberService;
@@ -61,8 +59,7 @@ class RuleServiceTest {
 
     @BeforeEach
     void setUp() {
-        ruleService = new RuleService(ruleRepository, deviceRepository, userRepository, deviceService, wsHandler,
-                memberService);
+        ruleService = new RuleService(ruleRepository, deviceRepository, deviceService, wsHandler, memberService);
 
         user = new User("Test User", EMAIL, "hashed");
         ReflectionTestUtils.setField(user, "id", 1L);

--- a/backend/src/test/java/at/jku/se/smarthome/service/ScheduleServiceTest.java
+++ b/backend/src/test/java/at/jku/se/smarthome/service/ScheduleServiceTest.java
@@ -9,7 +9,6 @@ import at.jku.se.smarthome.dto.ScheduleRequest;
 import at.jku.se.smarthome.dto.ScheduleResponse;
 import at.jku.se.smarthome.repository.DeviceRepository;
 import at.jku.se.smarthome.repository.ScheduleRepository;
-import at.jku.se.smarthome.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,7 +39,6 @@ class ScheduleServiceTest {
 
     @Mock private ScheduleRepository scheduleRepository;
     @Mock private DeviceRepository deviceRepository;
-    @Mock private UserRepository userRepository;
     @Mock private DeviceService deviceService;
     @Mock private ActivityLogService activityLogService;
     @Mock private MemberService memberService;
@@ -59,7 +57,7 @@ class ScheduleServiceTest {
     void setUp() {
         objectMapper = new ObjectMapper();
         scheduleService = new ScheduleService(
-                scheduleRepository, deviceRepository, userRepository,
+                scheduleRepository, deviceRepository,
                 deviceService, activityLogService, objectMapper, memberService);
 
         user = new User("Test User", EMAIL, "hashed");

--- a/frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/frontend/src/app/features/dashboard/dashboard.component.ts
@@ -61,7 +61,7 @@ import { DeviceCardComponent } from '../../shared/components/device-card/device-
             <div class="stat-label">Active Now</div>
           </div>
         </mat-card>
-        <mat-card class="stat-card">
+        <mat-card class="stat-card" *ngIf="auth.isOwner">
           <div class="stat-icon-bg" style="background:rgba(139,92,246,0.1);">
             <mat-icon style="color:#8B5CF6;">rule</mat-icon>
           </div>
@@ -173,10 +173,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
       error: () => { this.recentActivity = []; }
     });
 
-    this.ruleService.getRules().subscribe({
-      next: rules => { this.rulesCount = rules.filter(r => r.enabled).length; },
-      error: () => { this.rulesCount = 0; }
-    });
+    if (this.auth.isOwner) {
+      this.ruleService.getRules().subscribe({
+        next: rules => { this.rulesCount = rules.filter(r => r.enabled).length; },
+        error: () => { this.rulesCount = 0; }
+      });
+    }
 
     if (this.auth.isOwner) {
       this.vacationModeService.getVacationModes().subscribe({


### PR DESCRIPTION
… resolveUser() + userRepository removed from RuleService and ScheduleService (field, constructor param, Javadoc @param).

  RuleServiceTest, ScheduleServiceTest, and DeviceServiceTest all updated to match the new constructor signatures.
  2. resolveOwner helper — Added to ScheduleService, replaced the 5 repeated requireOwnerRole + resolveEffectiveOwner pairs in getSchedules, createSchedule, updateSchedule, setEnabled, and deleteSchedule.
  3. fromActionValue factory — Added to DeviceStateRequest with Javadoc. RuleService.buildActionRequest and SceneService.buildStateRequest both replaced with a single delegating call. The COVER/boolean logic now lives in exactly one place.